### PR TITLE
Feature/imposto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -61,26 +56,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/br/com/calculoImpostos/api/controllers/TaxController.java
+++ b/src/main/java/br/com/calculoImpostos/api/controllers/TaxController.java
@@ -1,0 +1,43 @@
+package br.com.calculoImpostos.api.controllers;
+
+
+import br.com.calculoImpostos.api.dtos.TaxRequestDTO;
+import br.com.calculoImpostos.api.dtos.TaxResponseDTO;
+import br.com.calculoImpostos.api.services.TaxService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tipos")
+public class TaxController {
+    private final TaxService taxService;
+
+    public TaxController(TaxService taxService) {
+        this.taxService = taxService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TaxResponseDTO> searchTaxById(@PathVariable Long id) {
+        return ResponseEntity.ok(taxService.searchTaxById(id));
+    }
+    @GetMapping()
+    public ResponseEntity<List<TaxResponseDTO>> searchAllTaxes() {
+        return ResponseEntity.ok(taxService.searchAllTaxes());
+    }
+
+
+    @PostMapping
+    public ResponseEntity<TaxResponseDTO> registerTax(@RequestBody TaxRequestDTO request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(taxService.registerTax(request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTax(@PathVariable Long id) {
+        taxService.deleteTax(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/br/com/calculoImpostos/api/dtos/TaxRequestDTO.java
+++ b/src/main/java/br/com/calculoImpostos/api/dtos/TaxRequestDTO.java
@@ -1,0 +1,13 @@
+package br.com.calculoImpostos.api.dtos;
+
+
+import br.com.calculoImpostos.api.enums.TypeTax;
+
+public record TaxRequestDTO(
+        TypeTax name,
+        String description,
+        double aliquot
+) {
+
+}
+

--- a/src/main/java/br/com/calculoImpostos/api/dtos/TaxResponseDTO.java
+++ b/src/main/java/br/com/calculoImpostos/api/dtos/TaxResponseDTO.java
@@ -1,0 +1,12 @@
+package br.com.calculoImpostos.api.dtos;
+
+
+import br.com.calculoImpostos.api.enums.TypeTax;
+
+public record TaxResponseDTO(
+        Long id,
+        TypeTax name,
+        String description,
+        double aliquot
+) {
+}

--- a/src/main/java/br/com/calculoImpostos/api/enums/TypeTax.java
+++ b/src/main/java/br/com/calculoImpostos/api/enums/TypeTax.java
@@ -1,0 +1,8 @@
+package br.com.calculoImpostos.api.enums;
+
+public enum TypeTax {
+    ICMS,
+    ISS,
+    IPI;
+
+}

--- a/src/main/java/br/com/calculoImpostos/api/exceptions/ErrorResponse.java
+++ b/src/main/java/br/com/calculoImpostos/api/exceptions/ErrorResponse.java
@@ -1,0 +1,23 @@
+package br.com.calculoImpostos.api.exceptions;
+
+public class ErrorResponse {
+    private int statusCode;
+    private String message;
+
+    public ErrorResponse(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public String getMensagem() {
+        return message;
+    }
+
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+
+}
+

--- a/src/main/java/br/com/calculoImpostos/api/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/calculoImpostos/api/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package br.com.calculoImpostos.api.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TaxNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(TaxNotFoundException ex) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+    @ExceptionHandler(TaxAlreadyRegisteredException.class)
+    public ResponseEntity<ErrorResponse> handleResourceRegisteredException(TaxAlreadyRegisteredException ex) {
+        return buildErrorResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        ex.printStackTrace();
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Ocorreu um erro inesperado.");
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String message) {
+        ErrorResponse errorResponse = new ErrorResponse(status.value(), message);
+        return new ResponseEntity<>(errorResponse, status);
+    }
+}

--- a/src/main/java/br/com/calculoImpostos/api/exceptions/TaxAlreadyRegisteredException.java
+++ b/src/main/java/br/com/calculoImpostos/api/exceptions/TaxAlreadyRegisteredException.java
@@ -1,0 +1,8 @@
+package br.com.calculoImpostos.api.exceptions;
+
+public class TaxAlreadyRegisteredException extends RuntimeException {
+
+    public TaxAlreadyRegisteredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/calculoImpostos/api/exceptions/TaxNotFoundException.java
+++ b/src/main/java/br/com/calculoImpostos/api/exceptions/TaxNotFoundException.java
@@ -1,0 +1,8 @@
+package br.com.calculoImpostos.api.exceptions;
+
+public class TaxNotFoundException extends RuntimeException {
+
+    public TaxNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/calculoImpostos/api/models/TaxModel.java
+++ b/src/main/java/br/com/calculoImpostos/api/models/TaxModel.java
@@ -1,0 +1,49 @@
+package br.com.calculoImpostos.api.models;
+
+import br.com.calculoImpostos.api.enums.TypeTax;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "impostos")
+public class TaxModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(unique = true)
+    private TypeTax name;
+
+    private String description;
+
+    private Double aliquot;
+
+    public TaxModel() {
+    }
+
+    public TaxModel(Long id, TypeTax name, String description, Double aliquot) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.aliquot = aliquot;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public TypeTax getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Double getAliquot() {
+        return aliquot;
+    }
+}
+
+

--- a/src/main/java/br/com/calculoImpostos/api/repositories/TaxRepository.java
+++ b/src/main/java/br/com/calculoImpostos/api/repositories/TaxRepository.java
@@ -1,0 +1,15 @@
+package br.com.calculoImpostos.api.repositories;
+
+
+import br.com.calculoImpostos.api.enums.TypeTax;
+import br.com.calculoImpostos.api.models.TaxModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface TaxRepository extends JpaRepository<TaxModel, Long> {
+
+    Optional<TaxModel> findByName(TypeTax name);
+
+}

--- a/src/main/java/br/com/calculoImpostos/api/services/TaxService.java
+++ b/src/main/java/br/com/calculoImpostos/api/services/TaxService.java
@@ -1,0 +1,21 @@
+package br.com.calculoImpostos.api.services;
+
+
+import br.com.calculoImpostos.api.dtos.TaxRequestDTO;
+import br.com.calculoImpostos.api.dtos.TaxResponseDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface TaxService {
+
+    TaxResponseDTO searchTaxById(Long id);
+
+    List<TaxResponseDTO> searchAllTaxes();
+
+    TaxResponseDTO registerTax(TaxRequestDTO request);
+
+    void deleteTax(Long id);
+
+}

--- a/src/main/java/br/com/calculoImpostos/api/services/TaxServiceImpl.java
+++ b/src/main/java/br/com/calculoImpostos/api/services/TaxServiceImpl.java
@@ -1,0 +1,77 @@
+package br.com.calculoImpostos.api.services;
+
+
+import br.com.calculoImpostos.api.dtos.TaxRequestDTO;
+import br.com.calculoImpostos.api.dtos.TaxResponseDTO;
+import br.com.calculoImpostos.api.enums.TypeTax;
+import br.com.calculoImpostos.api.exceptions.TaxAlreadyRegisteredException;
+import br.com.calculoImpostos.api.exceptions.TaxNotFoundException;
+import br.com.calculoImpostos.api.models.TaxModel;
+import br.com.calculoImpostos.api.repositories.TaxRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TaxServiceImpl implements TaxService {
+
+    private final TaxRepository taxRepository;
+
+    public TaxServiceImpl(TaxRepository taxRepository) {
+        this.taxRepository = taxRepository;
+    }
+
+    @Override
+    public TaxResponseDTO registerTax(TaxRequestDTO request) {
+        validateTaxName(request.name());
+        TaxModel tax = mapToModel(request);
+        TaxModel savedTax = taxRepository.save(tax);
+        return mapToResponseDTO(savedTax);
+    }
+
+    @Override
+    public void deleteTax(Long id) {
+        if (!taxRepository.existsById(id)) {
+            throw new TaxNotFoundException("Imposto com ID " + id + " não encontrado.");
+        }
+        taxRepository.deleteById(id);
+    }
+
+    @Override
+    public TaxResponseDTO searchTaxById(Long id) {
+        TaxModel tax = taxRepository.findById(id)
+                .orElseThrow(() -> new TaxNotFoundException("Imposto com ID " + id + " não encontrado."));
+        return mapToResponseDTO(tax);
+    }
+
+    @Override
+    public List<TaxResponseDTO> searchAllTaxes() {
+        return taxRepository.findAll()
+                .stream()
+                .map(this::mapToResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    private TaxModel mapToModel(TaxRequestDTO request) {
+        return new TaxModel(
+                null,
+                request.name(),
+                request.description(),
+                request.aliquot());
+    }
+
+    private TaxResponseDTO mapToResponseDTO(TaxModel tax) {
+        return new TaxResponseDTO(
+                tax.getId(),
+                tax.getName(),
+                tax.getDescription(),
+                tax.getAliquot());
+    }
+
+    private void validateTaxName(TypeTax name) {
+        if (taxRepository.findByName(name).isPresent()) {
+            throw new TaxAlreadyRegisteredException("Imposto com nome " + name + " já está cadastrado.");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: calculo-de-impostos
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+  show-sql: true

--- a/src/test/java/br/com/calculoImpostos/api/exceptions/GlobalExceptionHandlerTest.java
+++ b/src/test/java/br/com/calculoImpostos/api/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,66 @@
+package br.com.calculoImpostos.api.exceptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    private GlobalExceptionHandler globalExceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        globalExceptionHandler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void testHandleTaxNotFoundException() {
+        // Arrange
+        String errorMessage = "Imposto com ID 1 não encontrado.";
+        TaxNotFoundException exception = new TaxNotFoundException(errorMessage);
+
+        // Act
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleResourceNotFoundException(exception);
+
+        // Assert
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Assertions.assertEquals(errorMessage, response.getBody().getMensagem());
+        Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), response.getBody().getStatusCode());
+    }
+    @Test
+    void testHandleGenericException() {
+        // Arrange
+        String expectedMessage = "Ocorreu um erro inesperado.";
+        Exception exception = new Exception("Erro genérico");
+
+        // Act
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleGenericException(exception);
+
+        // Assert
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        Assertions.assertEquals(expectedMessage, response.getBody().getMensagem());
+        Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getBody().getStatusCode());
+    }
+    @Test
+    void testHandleTaxAlreadyRegisteredException() {
+        // Arrange
+        String expectedMessage = "Imposto com nome ICMS já está cadastrado.";
+        TaxAlreadyRegisteredException exception = new TaxAlreadyRegisteredException(expectedMessage);
+
+        // Act
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleResourceRegisteredException(exception);
+
+        // Assert
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        Assertions.assertEquals(expectedMessage, response.getBody().getMensagem());
+        Assertions.assertEquals(HttpStatus.CONFLICT.value(), response.getBody().getStatusCode());
+    }
+}

--- a/src/test/java/br/com/calculoImpostos/api/models/TaxModelTest.java
+++ b/src/test/java/br/com/calculoImpostos/api/models/TaxModelTest.java
@@ -1,0 +1,17 @@
+package br.com.calculoImpostos.api.models;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class TaxModelTest {
+    @Test
+    void testCreateTaxModelWithDefaultConstructor() {
+        // Arrange & Act
+        TaxModel taxModel = new TaxModel();
+
+        // Assert
+        Assertions.assertNotNull(taxModel, " TaxModel não deve ser nulo.");
+    }
+
+}

--- a/src/test/java/br/com/calculoImpostos/api/services/TaxServiceImplTest.java
+++ b/src/test/java/br/com/calculoImpostos/api/services/TaxServiceImplTest.java
@@ -1,0 +1,129 @@
+package br.com.calculoImpostos.api.services;
+
+import br.com.calculoImpostos.api.dtos.TaxRequestDTO;
+import br.com.calculoImpostos.api.enums.TypeTax;
+import br.com.calculoImpostos.api.dtos.TaxResponseDTO;
+import br.com.calculoImpostos.api.exceptions.TaxNotFoundException;
+import br.com.calculoImpostos.api.exceptions.TaxAlreadyRegisteredException;
+import br.com.calculoImpostos.api.models.TaxModel;
+import br.com.calculoImpostos.api.repositories.TaxRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class TaxServiceImplTest {
+
+    @Mock
+    private TaxRepository taxRepository;
+
+    @InjectMocks
+    private TaxServiceImpl taxService;
+
+    @Test
+    void testRegisterTaxSuccessfully() {
+         // Arrange
+        TaxRequestDTO request = new TaxRequestDTO(TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 18.0);
+        TaxModel taxModel = new TaxModel(null, TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 18.0);
+        TaxModel savedTax = new TaxModel(1L, TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 18.0);
+
+        Mockito.when(taxRepository.findByName(request.name())).thenReturn(Optional.empty());
+        Mockito.when(taxRepository.save(Mockito.any(TaxModel.class))).thenReturn(savedTax);
+
+        // Act
+        TaxResponseDTO response = taxService.registerTax(request);
+
+        // Assert
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(1L, response.id());
+        Assertions.assertEquals(TypeTax.ICMS, response.name());
+    }
+    @Test
+    void testThrowExceptionWhenTaxNameAlreadyExists() {
+        // Arrange
+        TaxRequestDTO request = new TaxRequestDTO(TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 18.0);
+        TaxModel existingTax = new TaxModel(1L, TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 18.0);
+
+        Mockito.when(taxRepository.findByName(request.name())).thenReturn(Optional.of(existingTax));
+
+        // Act & Assert
+        Assertions.assertThrows(TaxAlreadyRegisteredException.class, () -> taxService.registerTax(request));
+    }
+
+    @Test
+    void testThrowExceptionWhenDeletingNonExistentTax() {
+        // Arrange
+        Long taxId = 1L;
+
+        Mockito.when(taxRepository.existsById(taxId)).thenReturn(false);
+
+        // Act & Assert
+        Assertions.assertThrows(TaxNotFoundException.class, () -> taxService.deleteTax(taxId));
+    }
+
+    @Test
+    void testReturnTaxById() {
+        // Arrange
+        Long taxId = 1L;
+        TaxModel taxModel = new TaxModel(taxId, TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 15.0);
+
+        Mockito.when(taxRepository.findById(taxId)).thenReturn(Optional.of(taxModel));
+
+        // Act
+        TaxResponseDTO response = taxService.searchTaxById(taxId);
+
+        // Assert
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(taxId, response.id());
+    }
+
+    @Test
+    void testThrowExceptionWhenTaxNotFoundById() {
+        // Arrange
+        Long taxId = 1L;
+
+        Mockito.when(taxRepository.findById(taxId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        Assertions.assertThrows(TaxNotFoundException.class, () -> taxService.searchTaxById(taxId));
+    }
+
+    @Test
+    void testReturnAllTaxes() {
+        // Arrange
+        List<TaxModel> taxes = List.of(
+                new TaxModel(1L, TypeTax.ICMS, "Imposto sobre Circulação de Mercadorias e Serviços", 15.0),
+                new TaxModel(2L, TypeTax.IPI, "Imposto sobre Produtos Industrializados", 10.0),
+                new TaxModel(3L, TypeTax.ISS, "Imposto sobre Serviços de Qualquer Natureza", 5.0)
+        );
+
+        Mockito.when(taxRepository.findAll()).thenReturn(taxes);
+
+        // Act
+        List<TaxResponseDTO> response = taxService.searchAllTaxes();
+
+        // Assert
+        Assertions.assertEquals(3, response.size());
+    }
+    @Test
+    void testDeleteTaxSuccessfully() {
+        // Arrange
+        Long taxId = 1L;
+        Mockito.when(taxRepository.existsById(taxId)).thenReturn(true);
+
+        // Act
+        taxService.deleteTax(taxId);
+
+        // Assert
+        Mockito.verify(taxRepository, Mockito.times(1)).deleteById(taxId);
+    }
+
+
+}

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=api


### PR DESCRIPTION
## Propósito
O propósito desta implementação  é fornecer  o gerenciamento de Impostos da API, permitindo que os usuários realizem operações como criação, listagem de todos, listagem por id e exclusão de impostos

## Implementações
As principais implementações  incluem:

Criação do Imposto:
Endpoint para adicionar um novo Imposto ao sistema.

Listagem de Impostos:
Endpoint para listar todos os Impostos cadastrados no sistema.

Listagem de Impostos por ID:
Endpoint para buscar detalhes de um Imposto cadastrado no sistema com base no ID.

Exclusão de Imposto:
Endpoint para remover um Imposto do sistema com base no ID.

Banco de Dados Postgres:
Utilização de um banco de dados Postgres para armazenar os dados dos impostos cadastrados 

Mensagens de erro personalizada:
Classes de erro personalizada de acordo com as necessidades da aplicação

Testes Unitários:
Cobertura de mais de 80% das linhas de código com foco principalmente nas classes de serviço
